### PR TITLE
Defer model loading until model is used

### DIFF
--- a/asreviewcontrib/nemo/feature_extractors/sentence_transformers.py
+++ b/asreviewcontrib/nemo/feature_extractors/sentence_transformers.py
@@ -6,6 +6,8 @@ __all__ = [
     "GTR",
 ]
 
+from functools import cached_property
+
 from asreview.models.feature_extractors import TextMerger
 from sentence_transformers import SentenceTransformer, models
 
@@ -29,11 +31,9 @@ class BaseSentenceTransformer:
         self.precision = precision
         self.verbose = verbose
 
-    @property
-    def model(self):
-        if not hasattr(self, "_model"):
-            self._model = self._load_model()
-        return self._model
+    @cached_property
+    def _model(self):
+        return self._load_model()
 
     def _load_model(self):
         model = SentenceTransformer(self.model_name)
@@ -47,7 +47,7 @@ class BaseSentenceTransformer:
         if self.verbose:
             print("Embedding text...")
 
-        embeddings = self.model.encode(texts, show_progress_bar=self.verbose)
+        embeddings = self._model.encode(texts, show_progress_bar=self.verbose)
 
         if self.normalize:
             from asreviewcontrib.nemo.utils import min_max_normalize


### PR DESCRIPTION
Feature extractors loaded the full model at initialization, also when no inference would be done on that instance of the feature extractor