### PR TITLE
Bump Keras version and add Accelerate dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "numpy>=1.26.4",
     "scikit-learn>=1.6.1",
     "sentence-transformers>=3.4.1",
+    "accelerate>=1.0.0",
     "torch>=2.1.0",
     "xgboost>=2.1.4",
 ]


### PR DESCRIPTION
Since we are using the sklearn wrappers in keras, we need to enforce `keras>=3.8.0`