### PR TITLE
Test ASReview Presets and reuse feature matrices

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -5,6 +5,7 @@ import pandas as pd
 import pytest
 from asreview.extensions import extensions
 from asreview.extensions import get_extension
+from asreview.models.balancers import Balanced
 from asreview.models.queriers import Max
 
 from asreviewcontrib.nemo.entrypoint import NemoEntryPoint
@@ -65,6 +66,80 @@ def test_all_fe_clf_combinations(feature_extractor):
         assert (
             feature_extractor.name in simulate._results["feature_extractor"].unique()
         ), "Feature extractor is not in results."
+
+
+def test_language_agnostic_l2_preset():
+    # Load dataset
+    data = asr.load_dataset(dataset_path)
+
+    # Define Active Learning Cycle
+    alc = asr.ActiveLearningCycle(
+        classifier=get_extension("models.classifiers", "svm").load()(
+            loss="squared_hinge", C=0.4
+        ),
+        feature_extractor=get_extension(
+            "models.feature_extractors", "multilingual-e5-large"
+        ).load()(),
+        balancer=Balanced(ratio=5),
+        querier=Max(),
+    )
+    # Run simulation
+    simulate = asr.Simulate(
+        X=data,
+        labels=data["included"],
+        cycles=[alc],
+    )
+    simulate.label([0, 1])
+    simulate.review()
+    assert isinstance(simulate._results, pd.DataFrame)
+    assert simulate._results.shape[0] > 2 and simulate._results.shape[0] <= 6, (
+        "Simulation produced incorrect number of results."
+    )
+    assert (
+        get_extension("models.classifiers", "svm").load()().name
+        in simulate._results["classifier"].unique()
+    ), "Classifier is not in results."
+    assert (
+        get_extension("models.feature_extractors", "multilingual-e5-large")
+        .load()()
+        .name
+        in simulate._results["feature_extractor"].unique()
+    ), "Feature extractor is not in results."
+
+
+def test_heavy_h3_preset():
+    # Load dataset
+    data = asr.load_dataset(dataset_path)
+
+    # Define Active Learning Cycle
+    alc = asr.ActiveLearningCycle(
+        classifier=get_extension("models.classifiers", "svm").load()(
+            loss="squared_hinge", C=0.4
+        ),
+        feature_extractor=get_extension("models.feature_extractors", "sbert").load()(),
+        balancer=Balanced(ratio=5),
+        querier=Max(),
+    )
+    # Run simulation
+    simulate = asr.Simulate(
+        X=data,
+        labels=data["included"],
+        cycles=[alc],
+    )
+    simulate.label([0, 1])
+    simulate.review()
+    assert isinstance(simulate._results, pd.DataFrame)
+    assert simulate._results.shape[0] > 2 and simulate._results.shape[0] <= 6, (
+        "Simulation produced incorrect number of results."
+    )
+    assert (
+        get_extension("models.classifiers", "svm").load()().name
+        in simulate._results["classifier"].unique()
+    ), "Classifier is not in results."
+    assert (
+        get_extension("models.feature_extractors", "sbert").load()().name
+        in simulate._results["feature_extractor"].unique()
+    ), "Feature extractor is not in results."
 
 
 def test_get_all_models():


### PR DESCRIPTION
Adds tests for the asreview presets (l2 and h3)
Since ASReview simply calls `.fit_transform()` when `skip_transform=False` anyways, we can preprocess and reuse the feature matrices and set `skip_transform=True`.