### PR TITLE
Improve Tests, Classifiers, and Transformers

### DIFF
--- a/asreviewcontrib/dory/classifiers/adaboost.py
+++ b/asreviewcontrib/dory/classifiers/adaboost.py
@@ -28,11 +28,17 @@ class AdaBoost(AdaBoostClassifier):
     label = "AdaBoost"
 
     def __init__(
-        self, estimator=None, n_estimators=50, learning_rate=1.0, random_state=None
+        self,
+        estimator=None,
+        n_estimators=50,
+        learning_rate=1.0,
+        random_state=None,
+        **kwargs,
     ):
         super().__init__(
             estimator=estimator,
             n_estimators=n_estimators,
             learning_rate=learning_rate,
             random_state=random_state,
+            **kwargs,
         )

--- a/asreviewcontrib/dory/classifiers/neural_networks.py
+++ b/asreviewcontrib/dory/classifiers/neural_networks.py
@@ -1,9 +1,6 @@
 __all__ = ["DynamicNNClassifier", "NN2LayerClassifier", "WarmStartNNClassifier"]
 
-import os
 from math import ceil, log10
-
-os.environ["KERAS_BACKEND"] = "torch"
 
 from keras import layers, losses, models, optimizers, regularizers, wrappers
 

--- a/asreviewcontrib/dory/entrypoint.py
+++ b/asreviewcontrib/dory/entrypoint.py
@@ -21,6 +21,13 @@ class DoryEntryPoint:
         parser = argparse.ArgumentParser(prog="asreview dory")
         subparsers = parser.add_subparsers(dest="command", help="Subcommands for Dory")
 
+        parser.add_argument(
+            '--version', 
+            action='version', 
+            version=f'%(prog)s {self.version}', 
+            help="Show the version of the application"
+        )
+
         cache_parser = subparsers.add_parser(
             "cache", help="Cache specified entry points"
         )

--- a/asreviewcontrib/dory/entrypoint.py
+++ b/asreviewcontrib/dory/entrypoint.py
@@ -1,7 +1,14 @@
 import argparse
+import multiprocessing as mp
+import os
 from itertools import chain
 
+os.environ["KERAS_BACKEND"] = "torch"
+
+import torch
 from asreview.extensions import extensions, load_extension
+
+torch.set_num_threads(mp.cpu_count() - 1)
 
 
 class DoryEntryPoint:
@@ -22,10 +29,10 @@ class DoryEntryPoint:
         subparsers = parser.add_subparsers(dest="command", help="Subcommands for Dory")
 
         parser.add_argument(
-            '--version', 
-            action='version', 
-            version=f'%(prog)s {self.version}', 
-            help="Show the version of the application"
+            "--version",
+            action="version",
+            version=f"%(prog)s {self.version}",
+            help="Show the version of the application",
         )
 
         cache_parser = subparsers.add_parser(

--- a/asreviewcontrib/dory/entrypoint.py
+++ b/asreviewcontrib/dory/entrypoint.py
@@ -1,5 +1,4 @@
 import argparse
-import multiprocessing as mp
 import os
 from itertools import chain
 
@@ -8,7 +7,7 @@ os.environ["KERAS_BACKEND"] = "torch"
 import torch
 from asreview.extensions import extensions, load_extension
 
-torch.set_num_threads(mp.cpu_count() - 1)
+torch.set_num_threads(max(1, os.cpu_count() - 1))
 
 
 class DoryEntryPoint:

--- a/asreviewcontrib/dory/feature_extractors/transformer_embeddings.py
+++ b/asreviewcontrib/dory/feature_extractors/transformer_embeddings.py
@@ -100,9 +100,9 @@ class BaseSentenceTransformer(BaseEstimator, TransformerMixin):
         )
 
         if self.quantize:
-            embeddings = quantize_embeddings(
-                embeddings, precision=self.precision
-            ).numpy()
+            embeddings = quantize_embeddings(embeddings, precision=self.precision)
+            if hasattr(embeddings, "numpy"):
+                embeddings = embeddings.numpy()
         return embeddings
 
 

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -1,0 +1,162 @@
+import io
+import re
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from asreviewcontrib.dory.entrypoint import DoryEntryPoint
+
+
+def test_execute_cache_calls_cache():
+    dory = DoryEntryPoint()
+    with patch.object(dory, "cache") as mock_cache:
+        dory.execute(["cache", "xgboost", "sbert"])
+        mock_cache.assert_called_once_with(["xgboost", "sbert"])
+
+
+@patch("asreviewcontrib.dory.entrypoint.load_extension")
+def test_cache_loads_fe_model(mock_load):
+    mock_fe_model = MagicMock()
+    mock_fe_model().named_steps = {"sentence_transformer": MagicMock(_model="dummy")}
+    mock_load.return_value = mock_fe_model
+
+    dory = DoryEntryPoint()
+
+    captured_output = io.StringIO()
+    sys.stdout = captured_output
+
+    dory.cache(["sbert"])
+
+    sys.stdout = sys.__stdout__
+    mock_load.assert_called_with("models.feature_extractors", "sbert")
+    assert "Loaded FE sbert" in captured_output.getvalue()
+
+
+@patch("asreviewcontrib.dory.entrypoint.load_extension")
+def test_cache_fallback_to_classifier(mock_load):
+    mock_load.side_effect = [ValueError("not a FE"), MagicMock()]
+
+    captured_output = io.StringIO()
+    sys.stdout = captured_output
+
+    dory = DoryEntryPoint()
+    dory.cache(["xgboost"])
+
+    sys.stdout = sys.__stdout__
+
+    assert mock_load.call_args_list == [
+        (("models.feature_extractors", "xgboost"),),
+        (("models.classifiers", "xgboost"),),
+    ]
+    assert "Loaded CLS xgboost" in captured_output.getvalue()
+
+
+@patch("asreviewcontrib.dory.entrypoint.load_extension")
+def test_cache_model_not_found(mock_load):
+    mock_load.side_effect = [ValueError("not FE"), ValueError("not CLS")]
+
+    dory = DoryEntryPoint()
+    with patch("builtins.print") as mock_print:
+        dory.cache(["unknown_model"])
+        mock_print.assert_any_call("Error: Model 'unknown_model' not found.")
+
+
+@patch("asreviewcontrib.dory.entrypoint.load_extension")
+@patch("builtins.print")
+def test_cache_handles_keyerror(mock_print, mock_load_extension):
+    # Mock an FE model that lacks 'sentence_transformer' in named_steps
+    mock_fe_model_instance = MagicMock()
+    mock_fe_model_instance.named_steps = {}  # Will raise KeyError
+    mock_fe_model = MagicMock(return_value=mock_fe_model_instance)
+    mock_load_extension.return_value = mock_fe_model
+
+    dory = DoryEntryPoint()
+    dory.cache(["sbert"])
+
+    # Ensure it still prints that the FE was loaded even if KeyError occurred
+    mock_print.assert_called_once_with("Loaded FE sbert")
+    mock_load_extension.assert_called_once_with("models.feature_extractors", "sbert")
+
+
+@patch.object(DoryEntryPoint, "_get_all_models")
+@patch.object(DoryEntryPoint, "cache")
+def test_execute_cache_all(mock_cache, mock_get_all):
+    xgboost_mock = MagicMock()
+    sbert_mock = MagicMock()
+    xgboost_mock.name = "xgboost"
+    sbert_mock.name = "sbert"
+
+    mock_get_all.return_value = [xgboost_mock, sbert_mock]
+
+    dory = DoryEntryPoint()
+    dory.execute(["cache-all"])
+
+    mock_cache.assert_called_once_with(["xgboost", "sbert"])
+
+
+@patch.object(DoryEntryPoint, "_get_all_models")
+@patch("builtins.print")
+def test_execute_list(mock_print, mock_get_all):
+    xgboost_mock = MagicMock()
+    sbert_mock = MagicMock()
+    xgboost_mock.name = "xgboost"
+    sbert_mock.name = "sbert"
+    mock_get_all.return_value = [xgboost_mock, sbert_mock]
+
+    dory = DoryEntryPoint()
+    dory.execute(["list"])
+
+    mock_print.assert_called_once_with(["xgboost", "sbert"])
+
+
+def test_execute_invalid_command_prints_help():
+    with patch("argparse.ArgumentParser") as mock_parser_cls:
+        mock_parser = MagicMock()
+        mock_parser_cls.return_value = mock_parser
+        mock_parser.parse_args.return_value = MagicMock(command="invalid")
+
+        dory = DoryEntryPoint()
+        dory.execute(["invalid"])
+
+        mock_parser.print_help.assert_called_once()
+
+
+def test_version_output(capsys):
+    dory = DoryEntryPoint()
+
+    with pytest.raises(SystemExit):
+        dory.execute(["--version"])
+
+    captured = capsys.readouterr()
+
+    assert re.search(r"asreview dory \d+", captured.out)
+
+
+@patch("asreviewcontrib.dory.entrypoint.extensions")
+def test_get_all_models(mock_extensions):
+    mock_fe_1 = MagicMock()
+    mock_fe_2 = MagicMock()
+    mock_cls_1 = MagicMock()
+    mock_cls_2 = MagicMock()
+
+    # Mock __str__ return values used in filtering logic
+    mock_fe_1.__str__.return_value = "asreviewcontrib.dory.sbert"
+    mock_fe_2.__str__.return_value = "external.sbert"
+    mock_cls_1.__str__.return_value = "asreviewcontrib.dory.xgboost"
+    mock_cls_2.__str__.return_value = "external.xgboost"
+
+    # Add a `.name` attribute for readability
+    mock_fe_1.name = "sbert"
+    mock_cls_1.name = "xgboost"
+
+    mock_extensions.side_effect = [
+        [mock_fe_1, mock_fe_2],
+        [mock_cls_1, mock_cls_2],
+    ]
+
+    dory = DoryEntryPoint()
+    models = dory._get_all_models()
+
+    assert len(models) == 2
+    assert {m.name for m in models} == {"sbert", "xgboost"}

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -10,15 +10,11 @@ from asreview.models.queriers import Max
 from asreviewcontrib.dory.entrypoint import DoryEntryPoint
 
 classifier_parameters = {
-    "svm": {"loss": "squared_hinge", "C": 0.15, "tol": 0.0002},
     "xgboost": {"max_depth": 5, "n_estimators": 250},
     "dynamic-nn": {"epochs": 30, "batch_size": 16},
     "nn-2-layer": {"epochs": 50, "verbose": 1},
     "warmstart-nn": {"epochs": 45, "shuffle": False},
-    "adaboost": {
-        "n_estimators": 30,
-        "learning_rate": 0.5,
-    },
+    "adaboost": {"n_estimators": 30, "learning_rate": 0.5},
 }
 
 feature_extractor_parameters = {
@@ -35,7 +31,7 @@ dataset_path = Path("tests/data/generic_labels.csv")
 # Get all classifiers and feature extractors from ASReview, filtering contrib models
 classifiers = [
     cls for cls in extensions("models.classifiers") if "asreviewcontrib" in str(cls)
-] + [get_extension("models.classifiers", "svm")]
+]
 feature_extractors = [
     fe for fe in extensions("models.feature_extractors") if "asreviewcontrib" in str(fe)
 ]

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -8,20 +8,23 @@ from asreview.models.balancers import Balanced
 from asreview.models.queriers import Max
 
 classifier_parameters = {
-    "svm": {"loss": "squared_hinge", "C": 0.15},
-    "xgboost": {"max_depth": 5},
-    "dynamic-nn": {"epochs": 30},
-    "nn-2-layer": {"epochs": 30},
-    "warmstart-nn": {"epochs": 30},
-    "adaboost": {"n_estimators": 30},
+    "svm": {"loss": "squared_hinge", "C": 0.15, "tol": 0.0002},
+    "xgboost": {"max_depth": 5, "n_estimators": 250},
+    "dynamic-nn": {"epochs": 30, "batch_size": 16},
+    "nn-2-layer": {"epochs": 50, "verbose": 1},
+    "warmstart-nn": {"epochs": 45, "shuffle": False},
+    "adaboost": {
+        "n_estimators": 30,
+        "learning_rate": 0.5,
+    },
 }
 
 feature_extractor_parameters = {
-    "labse": {"normalize": True},
-    "mxbai": {"normalize": True},
-    "sbert": {"normalize": True},
-    "multilingual-e5-large": {"normalize": True},
-    "gtr-t5-large": {"normalize": True},
+    "labse": {"normalize": True, "quantize": True},
+    "mxbai": {"normalize": True, "precision": "binary", "quantize": True},
+    "sbert": {"normalize": True, "verbose": False, "quantize": True},
+    "multilingual-e5-large": {"normalize": True, "sep": ",", "quantize": True},
+    "gtr-t5-large": {"normalize": True, "columns": ["title"], "quantize": True},
 }
 
 # Get all classifiers and feature extractors from ASReview, filtering contrib models

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -3,20 +3,16 @@ from pathlib import Path
 
 import asreview as asr
 import pytest
-from asreview.extensions import extensions, get_extension
+from asreview.extensions import extensions
 from asreview.models.balancers import Balanced
 from asreview.models.queriers import Max
 
 classifier_parameters = {
-    "svm": {"loss": "squared_hinge", "C": 0.15, "tol": 0.0002},
     "xgboost": {"max_depth": 5, "n_estimators": 250},
     "dynamic-nn": {"epochs": 30, "batch_size": 16},
     "nn-2-layer": {"epochs": 50, "verbose": 1},
     "warmstart-nn": {"epochs": 45, "shuffle": False},
-    "adaboost": {
-        "n_estimators": 30,
-        "learning_rate": 0.5,
-    },
+    "adaboost": {"n_estimators": 30, "learning_rate": 0.5},
 }
 
 feature_extractor_parameters = {
@@ -30,7 +26,7 @@ feature_extractor_parameters = {
 # Get all classifiers and feature extractors from ASReview, filtering contrib models
 classifiers = [
     cls for cls in extensions("models.classifiers") if "asreviewcontrib" in str(cls)
-] + [get_extension("models.classifiers", "svm")]
+]
 feature_extractors = [
     fe for fe in extensions("models.feature_extractors") if "asreviewcontrib" in str(fe)
 ]


### PR DESCRIPTION
General improvements for Dory (and reaching 98% test coverage!):

- add --version cmd
- add support for kwargs to adaboost
- add support for non-torch quantization
- add entrypoint tests
- test more complex combinations of hyperparameters for serialization and useage
- set torch num_threads and move setting torch as backend for keras