### PR TITLE
Refactor text input cleaning to adhere to stronger sentence-transformers typechecking

### DIFF
--- a/asreviewcontrib/dory/feature_extractors/huggingface_embeddings.py
+++ b/asreviewcontrib/dory/feature_extractors/huggingface_embeddings.py
@@ -5,7 +5,6 @@ from functools import cached_property
 from typing import Literal
 
 import numpy as np
-import pandas as pd
 import torch
 from asreview.models.feature_extractors import TextMerger
 from sklearn.base import BaseEstimator, TransformerMixin
@@ -13,7 +12,7 @@ from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import MinMaxScaler, Normalizer, StandardScaler
 from transformers import AutoModel, AutoTokenizer
 
-from .utils import Quantizer
+from .utils import Quantizer, clean_text_inputs
 
 torch.set_num_threads(max(1, os.cpu_count() - 1))
 
@@ -190,18 +189,6 @@ class HFEmbedder(BaseEstimator, TransformerMixin):
             except StopIteration:
                 return None
 
-    @staticmethod
-    def _clean_text_inputs(X):
-        if isinstance(X, pd.Series):
-            X = X.fillna("").astype(str).tolist()
-        elif isinstance(X, list):
-            X = ["" if x is None else str(x) for x in X]
-        elif isinstance(X, np.ndarray):
-            X = ["" if x is None else str(x) for x in X.tolist()]
-        else:
-            raise ValueError("Expected a list or ndarray of strings or pandas Series.")
-        return X
-
     def fit(self, X, y=None):
         return self
 
@@ -229,7 +216,7 @@ class HFEmbedder(BaseEstimator, TransformerMixin):
             raise ValueError(f"Unsupported pooling method: {self.pooling}")
 
     def transform(self, X, y=None):
-        X = self._clean_text_inputs(X)
+        X = clean_text_inputs(X)
 
         if self.verbose:
             print("Embedding using HuggingFace model...")

--- a/asreviewcontrib/dory/feature_extractors/sentence_transformer_embeddings.py
+++ b/asreviewcontrib/dory/feature_extractors/sentence_transformer_embeddings.py
@@ -17,7 +17,7 @@ from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import MinMaxScaler, Normalizer, StandardScaler
 
-from .utils import Quantizer
+from .utils import Quantizer, clean_text_inputs
 
 torch.set_num_threads(max(1, os.cpu_count() - 1))
 
@@ -142,10 +142,11 @@ class BaseSentenceTransformer(BaseEstimator, TransformerMixin):
     def transform(self, X, y=None):
         if self.verbose:
             print("Embedding text...")
-
+        
+        X = clean_text_inputs(X)
         embeddings = self._model.encode(X, show_progress_bar=self.verbose)
         embeddings = self._to_numpy(embeddings)
-
+        
         return embeddings
 
     def _to_numpy(self, arr):

--- a/asreviewcontrib/dory/feature_extractors/utils.py
+++ b/asreviewcontrib/dory/feature_extractors/utils.py
@@ -1,5 +1,19 @@
+import numpy as np
+import pandas as pd
 from sentence_transformers import quantize_embeddings
 from sklearn.base import BaseEstimator, TransformerMixin
+
+
+def clean_text_inputs(X):
+    if isinstance(X, pd.Series):
+        X = X.fillna("").astype(str).tolist()
+    elif isinstance(X, list):
+        X = ["" if x is None else str(x) for x in X]
+    elif isinstance(X, np.ndarray):
+        X = ["" if x is None else str(x) for x in X.tolist()]
+    else:
+        raise ValueError("Expected a list or ndarray of strings or pandas Series.")
+    return X
 
 
 class Quantizer(BaseEstimator, TransformerMixin):

--- a/tests/test_classifiers.py
+++ b/tests/test_classifiers.py
@@ -34,11 +34,12 @@ feature_extractors = [SmallHFEmbedderFE, SmallSentenceTransformerFE]
     ids=lambda val: getattr(val, "name", val) if hasattr(val, "name") else val,
 )
 def test_all_classifiers_with_extractors(clf_entry, fe_cls):
-    data = asr.load_dataset(dataset_path)
+    db = asr.load_dataset(dataset_path)
+    df = db.input.get_df()
 
     # Feature extraction
     fe = fe_cls()
-    fm = fe.fit_transform(data)
+    fm = fe.fit_transform(df)
 
     clf_name = clf_entry.name
     clf_kwargs = classifier_parameters.get(clf_name, {})
@@ -52,7 +53,7 @@ def test_all_classifiers_with_extractors(clf_entry, fe_cls):
 
     sim = asr.Simulate(
         X=fm,
-        labels=data["included"],
+        labels=df["included"],
         cycles=[alc],
         skip_transform=True,
     )

--- a/tests/test_feature_extractors.py
+++ b/tests/test_feature_extractors.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import asreview as asr
 import numpy as np
+import pandas as pd
 import pytest
 from dummy_feature_extractors import (DOC2VEC_TEST_CASES, HF_BAD_TEST_CASES,
                                       HF_TEST_CASES, ST_BAD_TEST_CASES,
@@ -9,6 +10,11 @@ from dummy_feature_extractors import (DOC2VEC_TEST_CASES, HF_BAD_TEST_CASES,
                                       SmallSentenceTransformerFE)
 
 from asreviewcontrib.dory.feature_extractors.doc2vec import Doc2Vec
+from asreviewcontrib.dory.feature_extractors.huggingface_embeddings import HFEmbedder
+from asreviewcontrib.dory.feature_extractors.sentence_transformer_embeddings import (
+    BaseSentenceTransformer,
+)
+from asreviewcontrib.dory.feature_extractors.utils import clean_text_inputs
 
 # Define dataset path
 dataset_path = Path("tests/data/generic_labels.csv")
@@ -54,3 +60,66 @@ ALL_FE_BAD_VARIANTS_IDS = [test_id for test_id, _ in HF_BAD_TEST_CASES] + [
 def test_feature_extractor_bad_variants(fe_cls, params):
     with pytest.raises(ValueError):
         fe_cls(**params).fit_transform(asr.load_dataset(dataset_path))
+
+
+# --- clean_text_inputs unit tests ---
+
+MIXED_INPUTS = ["hello", None, 42, 3.14, True, ""]
+EXPECTED_CLEANED = ["hello", "", "42", "3.14", "True", ""]
+
+
+def test_clean_text_inputs_list():
+    result = clean_text_inputs(MIXED_INPUTS)
+    assert result == EXPECTED_CLEANED
+
+
+def test_clean_text_inputs_series():
+    s = pd.Series(MIXED_INPUTS)
+    result = clean_text_inputs(s)
+    assert result == EXPECTED_CLEANED
+
+
+def test_clean_text_inputs_ndarray():
+    arr = np.array(MIXED_INPUTS, dtype=object)
+    result = clean_text_inputs(arr)
+    assert result == EXPECTED_CLEANED
+
+
+def test_clean_text_inputs_series_with_nan():
+    s = pd.Series([np.nan, "text", None])
+    result = clean_text_inputs(s)
+    assert result == ["", "text", ""]
+
+
+def test_clean_text_inputs_invalid_type():
+    with pytest.raises(ValueError):
+        clean_text_inputs("not a list or array")
+
+
+# --- Integration: base embedder transform with non-string inputs ---
+
+SMALL_ST_MODEL = "sentence-transformers/paraphrase-MiniLM-L3-v2"
+SMALL_HF_MODEL = "google/bert_uncased_L-2_H-128_A-2"
+
+NON_STRING_INPUTS = [
+    ["hello world", None, 42],
+    pd.Series(["hello world", None, 42]),
+    np.array(["hello world", None, 42], dtype=object),
+]
+NON_STRING_INPUT_IDS = ["list", "series", "ndarray"]
+
+
+@pytest.mark.parametrize("X", NON_STRING_INPUTS, ids=NON_STRING_INPUT_IDS)
+def test_sentence_transformer_transform_non_strings(X):
+    model = BaseSentenceTransformer(model_name=SMALL_ST_MODEL, verbose=False)
+    embeddings = model.transform(X)
+    assert embeddings.shape == (3, embeddings.shape[1])
+    assert embeddings.dtype.kind == "f"
+
+
+@pytest.mark.parametrize("X", NON_STRING_INPUTS, ids=NON_STRING_INPUT_IDS)
+def test_hf_embedder_transform_non_strings(X):
+    model = HFEmbedder(model_name=SMALL_HF_MODEL, verbose=False)
+    embeddings = model.transform(X)
+    assert embeddings.shape == (3, embeddings.shape[1])
+    assert embeddings.dtype.kind == "f"

--- a/tests/test_feature_extractors.py
+++ b/tests/test_feature_extractors.py
@@ -34,12 +34,13 @@ ALL_FE_VARIANTS_IDS = (
 
 @pytest.mark.parametrize("fe_cls,params", ALL_FE_VARIANTS, ids=ALL_FE_VARIANTS_IDS)
 def test_feature_extractor_variants(fe_cls, params):
-    data = asr.load_dataset(dataset_path)
-    features = fe_cls(**params).fit_transform(data)
+    db = asr.load_dataset(dataset_path)
+    df = db.input.get_df()
+    features = fe_cls(**params).fit_transform(df)
 
     assert features is not None, "Feature matrix is None"
     assert hasattr(features, "shape"), "Feature matrix must have a shape"
-    assert features.shape[0] == len(data), "One embedding per record"
+    assert features.shape[0] == len(df), "One embedding per record"
     assert features.ndim == 2, "Embeddings must be 2D (samples x features)"
     assert features.dtype.kind in {"f", "i", "u"}, "Expect numeric features"
     assert not np.allclose(features.std(axis=0), 0), "All embeddings are identical"
@@ -59,7 +60,8 @@ ALL_FE_BAD_VARIANTS_IDS = [test_id for test_id, _ in HF_BAD_TEST_CASES] + [
 )
 def test_feature_extractor_bad_variants(fe_cls, params):
     with pytest.raises(ValueError):
-        fe_cls(**params).fit_transform(asr.load_dataset(dataset_path))
+        db = asr.load_dataset(dataset_path)
+        fe_cls(**params).fit_transform(db.input.get_df())
 
 
 # --- clean_text_inputs unit tests ---

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -12,7 +12,8 @@ dataset_path = Path("tests/data/generic_labels.csv")
 
 def test_language_agnostic_l2_preset():
     # Load dataset
-    data = asr.load_dataset(dataset_path)
+    db = asr.load_dataset(dataset_path)
+    df = db.input.get_df()
 
     # Define Active Learning Cycle
     alc = asr.ActiveLearningCycle(
@@ -27,8 +28,8 @@ def test_language_agnostic_l2_preset():
     )
     # Run simulation
     simulate = asr.Simulate(
-        X=data,
-        labels=data["included"],
+        X=df,
+        labels=df["included"],
         cycles=[alc],
     )
     simulate.label([0, 1])
@@ -51,7 +52,8 @@ def test_language_agnostic_l2_preset():
 
 def test_heavy_h3_preset():
     # Load dataset
-    data = asr.load_dataset(dataset_path)
+    db = asr.load_dataset(dataset_path)
+    df = db.input.get_df()
 
     # Define Active Learning Cycle
     alc = asr.ActiveLearningCycle(
@@ -66,8 +68,8 @@ def test_heavy_h3_preset():
     )
     # Run simulation
     simulate = asr.Simulate(
-        X=data,
-        labels=data["included"],
+        X=df,
+        labels=df["included"],
         cycles=[alc],
     )
     simulate.label([0, 1])


### PR DESCRIPTION
This PR addresses an issue caused by ASReview using pd.Series objects and sentence-transformers expecting lists. Cleaning was already handled correctly for Huggingface-style embedders, this logic is now copied over to the sentence transformers style embedders.