### PR TITLE
Cap python version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
     "Topic :: Text Processing :: General",
 ]
 license = {text = "MIT"}
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.14"
 dynamic = ["version"]
 dependencies = [
     "asreview>=2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,8 @@ classifiers = [
     "Topic :: Text Processing :: General",
 ]
 license = {text = "MIT"}
+# Upper bound due to gensim not yet supporting Python 3.14
+# Track: https://github.com/piskvorky/gensim/pull/3627
 requires-python = ">=3.10,<3.14"
 dynamic = ["version"]
 dependencies = [


### PR DESCRIPTION
To address issues with Gensim not being able to install on Python 3.14, I am capping the required python version of Dory at `<3.14` for now.